### PR TITLE
Use alpine to shrink image to a reasonable size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,17 @@
 # docker push 639338366904.dkr.ecr.us-east-1.amazonaws.com/ping:latest
 
 # Download base image ubuntu 20.04
-FROM ubuntu:20.04
+#FROM ubuntu:20.04
+FROM alpine:3
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Update Software repository
 WORKDIR /opt/api
-RUN apt-get update \
-&& apt-get install -y nodejs npm git \
-&& rm -rf /var/lib/apt/lists/*
+RUN apk update \
+  && apk add --no-cache nodejs npm git
+#RUN apt-get update \
+#&& apt-get install -y nodejs npm git \
+#&& rm -rf /var/lib/apt/lists/*
 COPY . /opt/api/
 
 # EXPOSE and CMD


### PR DESCRIPTION
Use alpine to shrink image to a reasonable size; alpine is a barebones image (unfortunately with no cloud-init images, but they do have AWS AMIs).

```
$ docker images
REPOSITORY   TAG      IMAGE ID       CREATED              SIZE
<none>       <none>   0442cdc6cf31   49 seconds ago       76.1MB  <- alpine3
<none>       <none>   251c778a7888   About a minute ago   689MB   <- ubuntu20

```
MWAHAHAHA